### PR TITLE
Play 2.2 compatibility fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,11 @@ scalaBinaryVersion := "2.10"
 
 scalacOptions ++= Seq("-Xlint", "-deprecation", "-unchecked", "-encoding", "utf8", "-feature")
 
+scalacOptions in Test ++= Seq("-Yrangepos")
+
 resolvers ++= Seq(
+  Resolver.sonatypeRepo("releases"),
+  Resolver.sonatypeRepo("snapshots"),
   Resolver.typesafeRepo("releases"),
   Resolver.typesafeRepo("snapshots")
 )
@@ -18,5 +22,5 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % Option(System.getenv("PLAY_VERSION")).getOrElse("2.2.0-RC2") % "compile",
   "com.typesafe.play" %% "play-test" % Option(System.getenv("PLAY_VERSION")).getOrElse("2.2.0-RC2") % "test",
-  "org.specs2" % "specs2_2.10" % "1.14" % "test"
+  "org.specs2" %% "specs2" % "2.2.2" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ organization := "eu.teamon"
 
 name := "play-navigator"
 
-version := "0.4.0"
+version := "0.5.0"
 
-scalaVersion := "2.10.0"
+scalaVersion := "2.10.2"
 
 scalaBinaryVersion := "2.10"
 
@@ -18,8 +18,8 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "play" %% "play" % Option(System.getenv("PLAY_VERSION")).getOrElse("2.1.0") % "compile",
-  "play" %% "play-test" % Option(System.getenv("PLAY_VERSION")).getOrElse("2.1.0") % "test",
+  "com.typesafe.play" %% "play" % Option(System.getenv("PLAY_VERSION")).getOrElse("2.2.0-RC2") % "compile",
+  "com.typesafe.play" %% "play-test" % Option(System.getenv("PLAY_VERSION")).getOrElse("2.2.0-RC2") % "test",
   "org.specs2" % "specs2_2.10" % "1.14" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,4 +23,5 @@ libraryDependencies ++= Seq(
   "org.specs2" % "specs2_2.10" % "1.14" % "test"
 )
 
-publishTo := Some(Resolver.file("local-maven", new File("/Users/teamon/code/maven")))
+publishTo := Some(Resolver.file("local-maven", new File(Path.userHome.absolutePath + "/.m2/repository")))
+

--- a/build.sbt
+++ b/build.sbt
@@ -8,13 +8,11 @@ scalaVersion := "2.10.2"
 
 scalaBinaryVersion := "2.10"
 
-scalacOptions ++= Seq("-Xlint","-deprecation", "-unchecked","-encoding", "utf8", "-feature")
+scalacOptions ++= Seq("-Xlint", "-deprecation", "-unchecked", "-encoding", "utf8", "-feature")
 
 resolvers ++= Seq(
-  "typesafe" at "http://repo.typesafe.com/typesafe/repo",
-  Resolver.url("Play", url("http://download.playframework.org/ivy-releases/"))(Resolver.ivyStylePatterns),
-  "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/",
-  "Typesafe Releases Repository" at "http://repo.typesafe.com/typesafe/releases/"
+  Resolver.typesafeRepo("releases"),
+  Resolver.typesafeRepo("snapshots")
 )
 
 libraryDependencies ++= Seq(
@@ -22,6 +20,3 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-test" % Option(System.getenv("PLAY_VERSION")).getOrElse("2.2.0-RC2") % "test",
   "org.specs2" % "specs2_2.10" % "1.14" % "test"
 )
-
-publishTo := Some(Resolver.file("local-maven", new File(Path.userHome.absolutePath + "/.m2/repository")))
-

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,11 @@ resolvers ++= Seq(
   Resolver.typesafeRepo("snapshots")
 )
 
-libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play" % Option(System.getenv("PLAY_VERSION")).getOrElse("2.2.0-RC2") % "compile",
-  "com.typesafe.play" %% "play-test" % Option(System.getenv("PLAY_VERSION")).getOrElse("2.2.0-RC2") % "test",
-  "org.specs2" %% "specs2" % "2.2.2" % "test"
+libraryDependencies ++= (
+  val play_version = Option(System.getenv("PLAY_VERSION")).getOrElse("2.2.0") 
+  Seq(
+    "com.typesafe.play" %% "play" % play_version % "compile",
+    "com.typesafe.play" %% "play-test" % play_version % "test",
+    "org.specs2" %% "specs2" % "2.2.2" % "test"
+  )
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.3
+sbt.version=0.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,0 @@
-resolvers += "scct-github-repository" at "http://mtkopone.github.com/scct/maven-repo"
-
-addSbtPlugin("reaktor" %% "sbt-scct" % "0.2-SNAPSHOT")

--- a/src/test/scala/play/navigator/MatchingSpec.scala
+++ b/src/test/scala/play/navigator/MatchingSpec.scala
@@ -3,7 +3,7 @@ package play
 import play.navigator._
 import org.specs2.mutable._
 import play.api.test._
-import play.api.test.Helpers.{routeAndCall, contentAsString}
+import play.api.test.Helpers._
 import play.api.mvc._
 
 class MatchingSpec extends Specification {


### PR DESCRIPTION
These should be enough for working play 2.2 support. I also cleaned up the build files a bit. I removed the hardcoded local maven repo publishing as SBT now has a `publishM2` task that should to it better.

I also had to remove the `scct` dependency as it does not support sbt 0.13 currently. I found no code references to it, so I assume it was used for manually checking test coverage, correct?
